### PR TITLE
Transactions and database indexes

### DIFF
--- a/src/main/java/pan/artem/tinkoff/controller/CurrentWeatherController.java
+++ b/src/main/java/pan/artem/tinkoff/controller/CurrentWeatherController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import pan.artem.tinkoff.dto.WeatherDto;
+import pan.artem.tinkoff.dto.WeatherDtoSaveResult;
 import pan.artem.tinkoff.service.CurrentWeatherService;
 
 @AllArgsConstructor
@@ -29,8 +29,8 @@ public class CurrentWeatherController {
             }
     )
     @GetMapping
-    public ResponseEntity<WeatherDto> getCurrentWeather(@PathVariable String city) {
-        var weather = currentWeatherService.getCurrentWeather(city);
+    public ResponseEntity<WeatherDtoSaveResult> getCurrentWeather(@PathVariable String city) {
+        var weather = currentWeatherService.getAndSaveCurrentWeather(city);
         return ResponseEntity.ok(weather);
     }
 }

--- a/src/main/java/pan/artem/tinkoff/dto/WeatherDtoSaveResult.java
+++ b/src/main/java/pan/artem/tinkoff/dto/WeatherDtoSaveResult.java
@@ -1,0 +1,4 @@
+package pan.artem.tinkoff.dto;
+
+public record WeatherDtoSaveResult(WeatherFullDto weatherDto, String error) {
+}

--- a/src/main/java/pan/artem/tinkoff/dto/externalservice/ConditionDto.java
+++ b/src/main/java/pan/artem/tinkoff/dto/externalservice/ConditionDto.java
@@ -1,0 +1,4 @@
+package pan.artem.tinkoff.dto.externalservice;
+
+public record ConditionDto(String text) {
+}

--- a/src/main/java/pan/artem/tinkoff/dto/externalservice/CurrentDto.java
+++ b/src/main/java/pan/artem/tinkoff/dto/externalservice/CurrentDto.java
@@ -3,5 +3,6 @@ package pan.artem.tinkoff.dto.externalservice;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 
-public record CurrentDto(@JsonProperty("temp_c") @NotNull Integer temperature) {
+public record CurrentDto(@JsonProperty("temp_c") @NotNull Integer temperature,
+                         @NotNull ConditionDto condition) {
 }

--- a/src/main/java/pan/artem/tinkoff/entity/WeatherType.java
+++ b/src/main/java/pan/artem/tinkoff/entity/WeatherType.java
@@ -15,6 +15,7 @@ import java.util.List;
 public class WeatherType {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String description;
 

--- a/src/main/java/pan/artem/tinkoff/service/CurrentWeatherService.java
+++ b/src/main/java/pan/artem/tinkoff/service/CurrentWeatherService.java
@@ -1,8 +1,11 @@
 package pan.artem.tinkoff.service;
 
-import pan.artem.tinkoff.dto.WeatherDto;
+import pan.artem.tinkoff.dto.WeatherDtoSaveResult;
+import pan.artem.tinkoff.dto.WeatherFullDto;
 
 public interface CurrentWeatherService {
 
-    WeatherDto getCurrentWeather(String city);
+    WeatherFullDto getCurrentWeather(String city);
+
+    WeatherDtoSaveResult getAndSaveCurrentWeather(String city);
 }

--- a/src/main/java/pan/artem/tinkoff/service/CurrentWeatherServiceImpl.java
+++ b/src/main/java/pan/artem/tinkoff/service/CurrentWeatherServiceImpl.java
@@ -1,24 +1,42 @@
 package pan.artem.tinkoff.service;
 
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
-import pan.artem.tinkoff.dto.WeatherDto;
+import pan.artem.tinkoff.dto.WeatherDtoSaveResult;
+import pan.artem.tinkoff.dto.WeatherFullDto;
 import pan.artem.tinkoff.dto.externalservice.CurrentWeatherDto;
+import pan.artem.tinkoff.exception.ResourceNotFoundException;
 
-import java.time.Instant;
+import java.time.*;
 
+@AllArgsConstructor
 @Service
 public class CurrentWeatherServiceImpl implements CurrentWeatherService {
 
     private final CurrentWeatherClient currentWeatherClient;
+    private final WeatherCrudService weatherCrudService;
 
-    public CurrentWeatherServiceImpl(CurrentWeatherClient currentWeatherClient) {
-        this.currentWeatherClient = currentWeatherClient;
+    @Override
+    public WeatherFullDto getCurrentWeather(String city) {
+        CurrentWeatherDto weatherDto = currentWeatherClient.getCurrentWeather(city);
+        int temperature = weatherDto.current().temperature();
+        String weatherType = weatherDto.current().condition().text();
+
+        return new WeatherFullDto(
+                temperature,
+                LocalDateTime.now(ZoneOffset.UTC),
+                weatherType
+        );
     }
 
     @Override
-    public WeatherDto getCurrentWeather(String city) {
-        CurrentWeatherDto weatherDto = currentWeatherClient.getCurrentWeather(city);
-        int temp = weatherDto.current().temperature();
-        return new WeatherDto(temp, Instant.now());
+    public WeatherDtoSaveResult getAndSaveCurrentWeather(String city) {
+        var weather = getCurrentWeather(city);
+        try {
+            weatherCrudService.updateWeather(city, weather);
+            return new WeatherDtoSaveResult(weather, null);
+        } catch (ResourceNotFoundException e) {
+            return new WeatherDtoSaveResult(weather, e.getMessage());
+        }
     }
 }

--- a/src/main/java/pan/artem/tinkoff/service/WeatherServiceJPA.java
+++ b/src/main/java/pan/artem/tinkoff/service/WeatherServiceJPA.java
@@ -2,6 +2,8 @@ package pan.artem.tinkoff.service;
 
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
 import pan.artem.tinkoff.dto.WeatherFullDto;
 import pan.artem.tinkoff.entity.City;
 import pan.artem.tinkoff.entity.Weather;
@@ -34,9 +36,9 @@ public class WeatherServiceJPA implements WeatherCrudService {
     private WeatherType getWeatherType(String description) {
         var weatherType = weatherTypeRepositoryJPA.getByDescription(description);
         if (weatherType == null) {
-            throw new ResourceNotFoundException(
-                    "No weather type with description '" + description + "' found"
-            );
+            weatherType = new WeatherType();
+            weatherType.setDescription(description);
+            weatherTypeRepositoryJPA.save(weatherType);
         }
         return weatherType;
     }
@@ -74,6 +76,7 @@ public class WeatherServiceJPA implements WeatherCrudService {
         ));
     }
 
+    @Transactional(isolation = Isolation.SERIALIZABLE)
     @Override
     public void addWeather(String city, WeatherFullDto weatherDto) {
         var cityEntity = getCity(city);
@@ -81,6 +84,7 @@ public class WeatherServiceJPA implements WeatherCrudService {
         addWeather(cityEntity, weatherDto, weatherType);
     }
 
+    @Transactional(isolation = Isolation.SERIALIZABLE)
     @Override
     public boolean updateWeather(String city, WeatherFullDto weatherDto) {
         var cityEntity = getCity(city);

--- a/src/main/resources/changelog/v-0.0/2023-10-30--01-initial-schema-import.xml
+++ b/src/main/resources/changelog/v-0.0/2023-10-30--01-initial-schema-import.xml
@@ -14,9 +14,15 @@
                 <constraints primaryKey="true" nullable="false"/>
             </column>
             <column name="name" type="varchar(50)">
-                <constraints nullable="false"/>
+                <constraints nullable="false" unique="true"/>
             </column>
         </createTable>
+    </changeSet>
+
+    <changeSet id="city-index" author="panart">
+        <createIndex tableName="city" indexName="city_index" unique="true">
+            <column name="name"/>
+        </createIndex>
     </changeSet>
 
     <changeSet id="weather_type-table" author="panart">
@@ -28,6 +34,12 @@
                 <constraints nullable="false" unique="true"/>
             </column>
         </createTable>
+    </changeSet>
+
+    <changeSet id="weather_type-index" author="panart">
+        <createIndex tableName="weather_type" indexName="weather_type_index" unique="true">
+            <column name="description"/>
+        </createIndex>
     </changeSet>
 
     <changeSet id="weather-table" author="panart">
@@ -48,6 +60,13 @@
                 <constraints foreignKeyName="fk_city" references="city(id)"/>
             </column>
         </createTable>
+    </changeSet>
+
+    <changeSet id="weather-index" author="panart">
+        <createIndex tableName="weather" indexName="weather_index">
+            <column name="temperature"/>
+            <column name="date_time"/>
+        </createIndex>
     </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
Requests for getting weather from external service also add a weather record.
If no `weather_type` with specified description found, a new one will be created.
Transaction management added in 2 implementations of repository-service level: JDBC and Spring JPA.
Created indexes for all 3 tables, didn't add clustered ones because H2 will pre-create it for primary keys.